### PR TITLE
Fix zookeeper deploy steps - no cd

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -32,7 +32,6 @@ Deploy a 5-node cluster of Zookeeper to Amazon AWS:
 
 ```
 git clone https://github.com/cppforlife/zookeeper-release
-cd zookeeper-release
 export BOSH_ENVIRONMENT=aws
 export BOSH_DEPLOYMENT=zookeeper
 bosh deploy zookeeper-release/manifests/zookeeper.yml


### PR DESCRIPTION
The zookeeper deploy example doesn't require the cd since the deploy line is providing a full path to the manifest. Remove the cd so that this works in case someone tries it.