### PR TITLE
enhance instance group members quantification

### DIFF
--- a/docs/deployment-manifests-part-1.md
+++ b/docs/deployment-manifests-part-1.md
@@ -67,7 +67,7 @@ If you deployed `zookeeper/0.0.7` every day for a year, you would always be depl
 
 In the deployment manifest, we decide which instances install which job templates/packages within the `instance_groups` section.
 
-The `zookeeper.yml` example above specifies as single long-running group of instances:
+The `zookeeper.yml` example above specifies one long-running group of instances:
 
 ```yaml
 instance_groups:


### PR DESCRIPTION
"one" in this context sounds better than "as single", or maybe "as single" was meant to be "a single"