### PR TITLE
enhance instance group's jobs intro

### DIFF
--- a/docs/deployment-manifests-part-1.md
+++ b/docs/deployment-manifests-part-1.md
@@ -84,7 +84,7 @@ This group of instances will be known within the deployment by its name `zookeep
 
 Each instance in the group will have a 10GB persistent disk (the plain number `10240` is in MB).
 
-The software, configuration, and start/stop scripts running on each `zookeeper` instance is described by the `jobs:` section of an instance group.
+The `jobs` section of an instance group describes how to configure and run software on each `zookeeper` instance.
 
 ```yaml
 jobs:


### PR DESCRIPTION
* configuration and start/stop scripts are barely running on each instance
* "software, configuration and start/stop scripts" implies "are" instead of "is"
* not sure if semicolon in `jobs` section name is intentional
* new phrasing seems to be shorter, and more valid