### PR TITLE
enhance vm-types samples for cloud infras

### DIFF
--- a/docs/deployment-manifests-part-1.md
+++ b/docs/deployment-manifests-part-1.md
@@ -157,7 +157,9 @@ Each BOSH director has a Cloud Config specification. We can download and view a 
 bosh cloud-config
 ```
 
-There are several areas of configuration but for now let's look at one - `vm_type` - the specification of the size of servers. Several examples of Cloud Config `vm_types` sections for popular cloud infrastructures are presented below:
+Cloud Config configuration hierarchy is quite rich. For now let's look at server resource specifications referred to as `vm_types`.
+
+Several examples of Cloud Config `vm_types` sections for popular cloud infrastructures are presented below:
 
 * GCP:
 

--- a/docs/deployment-manifests-part-1.md
+++ b/docs/deployment-manifests-part-1.md
@@ -157,7 +157,9 @@ Each BOSH director has a Cloud Config specification. We can download and view a 
 bosh cloud-config
 ```
 
-There are several areas of configuration but for now let's look at one - `vm_type` - the specification of the size of servers. An example of a `bosh cloud-config` for GCP might look like:
+There are several areas of configuration but for now let's look at one - `vm_type` - the specification of the size of servers. Several examples of Cloud Config `vm_types` sections for popular cloud infrastructures are presented below:
+
+* GCP:
 
 ```yaml
 vm_types:
@@ -168,7 +170,7 @@ vm_types:
     root_disk_type: pd-ssd
 ```
 
-For Amazon EC2 it might include:
+* Amazon EC2:
 
 ```yaml
 vm_types:
@@ -179,7 +181,7 @@ vm_types:
       size: 20_000
 ```
 
-For vSphere it might include:
+* vSphere:
 
 ```yaml
 vm_types:


### PR DESCRIPTION
* we are discussing cloud config, `bosh cloud config` is just a way to access it
* we are focusing on `vm-types` section, not the complete cloud config
* bullet points eliminate the need for repetitive sentences for each cloud infra