### PR TITLE
Fix format of `migrated_from` attribute

### DIFF
--- a/docs/deployment-updates.md
+++ b/docs/deployment-updates.md
@@ -342,7 +342,9 @@ To **rename** the `zookeeper` instance group in our `zookeeper` deployment manif
 ```yaml
 instance_groups:
 - name: zk
-  migrated_from: [zookeeper, zookeeper-instances]
+  migrated_from:
+  - name: zookeeper
+  - name: zookeeper-instances
   ...
 ```
 


### PR DESCRIPTION
This is an array of hashes of name and (optionally) AZ rather than an
array of just values